### PR TITLE
Fix bug in gtk popup menu

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -45,7 +45,7 @@ void menu_open(void) {
 	
 	gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM(menu_item_msgskip_on), get_skipMode());
 	gtk_check_menu_item_set_active (GTK_CHECK_MENU_ITEM(menu_item_msgskip_off), !get_skipMode());
-	gtk_menu_popup(GTK_MENU(menu_window_popup), NULL, NULL, NULL, NULL, 0, 100);
+	gtk_menu_popup(GTK_MENU(menu_window_popup), NULL, NULL, NULL, NULL, 0, gtk_get_current_event_time());
 	gtk_widget_show(menu_window_popup);
 	nact->popupmenu_opened = TRUE;
 }


### PR DESCRIPTION
Fixes a bug where the game freezes instead of opening the popup menu.
It looks like gtk ignores calls to gtk_menu_popup if the event timestamp is too old. This causes the game to pause, thinking the popup menu is open when it is not.