### PR TITLE
Fix infinite loop in MP command

### DIFF
--- a/src/cmd2F.c
+++ b/src/cmd2F.c
@@ -39,6 +39,9 @@
 #include "ald_manager.h"
 #include "LittleEndian.h"
 
+/* defined by cmdm.c */
+extern boolean have_eng_mp_patch;
+
 /* 選択 Window OPEN 時 callback */
 static int cb_sel_init_page = 0;
 static int cb_sel_init_address = 0;
@@ -446,7 +449,11 @@ void commands2F28() {
 	
 	strncpy(nact->game_title_name, title, 30);
 	ags_setWindowTitle(title);
-	
+
+	if (0 == strcmp(title, GT_RANCE3_ENG) || 0 == strcmp(title, GT_RANCE4_ENG)) {
+		have_eng_mp_patch = TRUE;
+	}
+
 	DEBUG_COMMAND("MT(new) %s:\n",title);
 }
 

--- a/src/cmdm.c
+++ b/src/cmdm.c
@@ -43,6 +43,8 @@ extern boolean Y3waitCancel;
 /* MI 用パラメータ */
 INPUTSTRING_PARAM mi_param;
 
+boolean have_eng_mp_patch = FALSE;
+
 void commandMS() {
 	/* Xコマンドで表示される文字列領域に文字列を入れる */
 	int num = getCaliValue();
@@ -62,21 +64,30 @@ void commandMP() {
 	int    num2 = getCaliValue();
 	const char bstr[3] = "\x81\x40"; // full-width whitespace
 	const char *src = v_str(num1 - 1);
-	char   *str = malloc(num2 * 2 + 1);
-
-	if (NULL == str) {
-		NOMEMERR();
-	}
-	
-	memset(str, 0, num2 * 2 + 1);
-
 	int chars = num2;
-	const char *p = src;
-	while (*p && chars > 0) {
-		p += CHECKSJIS1BYTE(*p) ? 2 : 1;
-		chars--;
+	char *str;
+
+	/* Patched English executable appends num2 spaces instead of truncating */
+	if (have_eng_mp_patch) {
+		str = calloc(strlen(src) + num2 * 2 + 1, 1);
+		if (NULL == str) {
+			NOMEMERR();
+		}
+		strcpy(str, src);
 	}
-	strncpy(str, src, p - src);
+	else {
+		str = calloc(num2 * 2 + 1, 1);
+		if (NULL == str) {
+			NOMEMERR();
+		}
+
+		const char *p = src;
+		while (*p && chars > 0) {
+			p += CHECKSJIS1BYTE(*p) ? 2 : 1;
+			chars--;
+		}
+		strncpy(str, src, p - src);
+	}
 	while (chars-- > 0) {
 		strcat(str, bstr);
 	}

--- a/src/gametitle.h
+++ b/src/gametitle.h
@@ -2,3 +2,5 @@
 #define GT_RANCE4 "‚q‚‚‚ƒ‚…‚S@|‹³’c‚ÌˆâY|@‚e‚‚’@‚v‚‰‚‚X‚T@"
 #define GT_RANCE5D "ƒ‰ƒ“ƒX‚T‚c@iSRj"
 #define GT_ESUKA "-BeatAngelEscalayer-"
+#define GT_RANCE3_ENG "Rance3"
+#define GT_RANCE4_ENG "Rance4 -Legacy of the Sect- For Win95 "


### PR DESCRIPTION
Fix an infinite loop that can when occur when printing messages that
contain 1-byte characters (i.e. half-width latin characters).

When 1-byte characters are used, 'blen' is not necessarily even. This code calculates the number of padding characters needed using sjis_count_char rather than assuming all characters are 2 bytes.

This fixes the English translations for various System 3.x games. I tested Rance IV and Kichikuou Rance, and they both seem to be fully working after this change.