### PR TITLE
Allow setting font antialiasing in .xsys35rc

### DIFF
--- a/src/xsystem35.c
+++ b/src/xsystem35.c
@@ -707,6 +707,13 @@ static void check_profile() {
 	if (param) {
 		fontface[FONT_MINCHO] = *param - '0';
 	}
+	/* Font antialiasing */
+	param = get_profile("antialias");
+	if (param) {
+		if (0 == strcmp(param, "Yes")) {
+			font_antialias = TRUE;
+		}
+	}
 	/* CD-ROM device name の設定 */
 	param = get_profile("cdrom_device");
 	if (param) {


### PR DESCRIPTION
This allows enabling antialiasing by default, so that you don't have to pass "-antialias" every time. Very useful if you don't have MS fonts (or just want to use a different font) since most fonts look pretty bad without antialiasing.