### PR TITLE
Fix fullscreen/resize issues on linux

### DIFF
--- a/src/sdl_event.c
+++ b/src/sdl_event.c
@@ -95,6 +95,9 @@ static void sdl_getEvent(void) {
 					SDL_WM_GrabInput(SDL_GRAB_OFF);
 #endif
 				break;
+			case SDL_WINDOWEVENT_EXPOSED:
+				sdl_dirty = TRUE;
+				break;
 			}
 			break;
 		case SDL_KEYDOWN:

--- a/src/sdl_mode.c
+++ b/src/sdl_mode.c
@@ -57,6 +57,7 @@ void sdl_setWindowSize(int x, int y, int w, int h) {
 	view_h = h;
 	
 	SDL_SetWindowSize(sdl_window, w, h);
+	SDL_RenderSetLogicalSize(sdl_renderer, w, h);
 	if (sdl_display)
 		SDL_FreeSurface(sdl_display);
 	if (sdl_texture)


### PR DESCRIPTION
This does three things:
* mouse inputs are properly scaled to the size of the window
* the window is letterboxed to maintain the original aspect ratio
* the screen is updated on SDL_WINDOWEVENT_EXPOSED events, which occur:
    * when entering/leaving fullscreen mode
    * when the window is resized
    * when switching workspaces
    * etc.