### PR TITLE
Quit immediately when window is closed

### DIFF
--- a/src/nact.c
+++ b/src/nact.c
@@ -218,7 +218,9 @@ static void nact_callback() {
 	}
 	if (nact->popupmenu_opened) {
 		menu_gtkmainiteration();
-		if (nact->is_quit) sys_exit(0);
+	}
+	if (nact->is_quit) {
+		sys_exit(0);
 	}
 }
 


### PR DESCRIPTION
This fixes an issue where the window stays open for a while after closing it via the titlebar controls, if the game was waiting for input.