### PR TITLE
Fix issue with uncancelled message wait

### DIFF
--- a/src/imput.c
+++ b/src/imput.c
@@ -111,14 +111,16 @@ void sys_hit_any_key() {
 	
 	/* message wait flag restore */
 	if (nact->messagewait_enable_save) {
+		/* if message wait was cancelled, consume that input */
+		if (!nact->messagewait_enable) {
+			while(0 == (key & hak_ignore_mask)) {
+				key = sys_keywait(INT_MAX, TRUE);
+			}
+			while(key & hak_releasewait_mask) {
+				key = sys_keywait(100, TRUE);
+			}
+		}
 		nact->messagewait_enable = nact->messagewait_enable_save ;
-		
-		while(0 == (key & hak_ignore_mask)) {
-			key = sys_keywait(INT_MAX, TRUE);
-		}
-		while(key & hak_releasewait_mask) {
-			key = sys_keywait(100, TRUE);
-		}
 	}
 
 	while(0 == (key & hak_ignore_mask)) {


### PR DESCRIPTION
`sys_hit_any_key` should only wait for two inputs if messagewait was actually cancelled.

This fixes a bug I noticed in the intro to Toushin Toshi II. If you let the messages finish printing without clicking, then you have to click twice before the game will start printing the next message.