### PR TITLE
texthook: explicitly flush stdout every line

### DIFF
--- a/src/texthook.c
+++ b/src/texthook.c
@@ -62,6 +62,7 @@ void texthook_message(const char *m) {
 void texthook_newline(void) {
 	if (newlines < 2) {
 		putchar('\n');
+		fflush(stdout);
 		newlines++;
 	}
 }
@@ -69,6 +70,7 @@ void texthook_newline(void) {
 void texthook_nextpage(void) {
 	while (newlines < 2) {
 		putchar('\n');
+		fflush(stdout);
 		newlines++;
 	}
 }


### PR DESCRIPTION
This allows processing the output line-by-line by a script. Otherwise, glibc fully buffers the output and the script wont get any input until the buffer is full.